### PR TITLE
Allow underscores in scenario tags

### DIFF
--- a/Behat-Features.JSON-tmLanguage
+++ b/Behat-Features.JSON-tmLanguage
@@ -7,7 +7,7 @@
     {
       "comment": "Behat scenario tags",
       "name": "storage.type.class.behat",
-      "match": "(@[A-Za-z0-9]+)"
+      "match": "(@[A-Za-z0-9_]+)"
     },
     {
       "comment": "Behat comment",

--- a/Behat-Features.tmLanguage
+++ b/Behat-Features.tmLanguage
@@ -16,7 +16,7 @@
       <key>comment</key>
       <string>Behat scenario tags</string>
       <key>match</key>
-      <string>(@[A-Za-z0-9]+)</string>
+      <string>(@[A-Za-z0-9_]+)</string>
       <key>name</key>
       <string>storage.type.class.behat</string>
     </dict>

--- a/examples.feature
+++ b/examples.feature
@@ -4,7 +4,7 @@ Feature: SublimeText2 Behat Features Syntax
   As a SublimeText2 and Behat user
   I need to see what the syntax highlight looks like
 
-  @outline @placeholders
+  @outline @placeholders @other_tag
   Scenario Outline: Eating
     Given there are <start> cucumbers
     When I eat <eat> cucumbers


### PR DESCRIPTION
My organization uses underscores in scenario tags to denote (among other things) which features run with and without Selenium.  We use tags such as `@level_1` and `@level_2`.  In this commit I added underscores to the scenario tags so the entire tag shows up the same color in Sublime.
